### PR TITLE
Hotfix#3

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -128,8 +128,8 @@ function(set_common_compile_options target)
             $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>
             -Wconversion
             -Wsign-conversion
-            -Wlogical-op
-            $<$<COMPILE_LANGUAGE:CXX>:-Wuseless-cast>
+            $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
+            $<$<AND:$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:-Wuseless-cast>
             -Wdouble-promotion
             $<$<COMPILE_LANGUAGE:CXX>:-Wold-style-cast>
             $<$<OR:$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,6.0.0>>>,$<AND:$<C_COMPILER_ID:GNU>,$<NOT:$<VERSION_LESS:$<C_COMPILER_VERSION>,6.0.0>>>>:-Wnull-dereference>

--- a/cmake/common/eprosima_libraries.cmake
+++ b/cmake/common/eprosima_libraries.cmake
@@ -78,7 +78,9 @@ macro(eprosima_find_thirdparty package thirdparty_name)
 
         option(THIRDPARTY_${package} "Activate the use of internal thirdparty ${package}" OFF)
 
-        if(THIRDPARTY OR THIRDPARTY_${package})
+        find_package(${package} QUIET)
+
+        if(NOT ${package}_FOUND AND (THIRDPARTY OR THIRDPARTY_${package}))
             execute_process(
                 COMMAND git submodule update --recursive --init "thirdparty/${thirdparty_name}"
                 WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -86,14 +88,13 @@ macro(eprosima_find_thirdparty package thirdparty_name)
                 )
 
             if(EXECUTE_RESULT EQUAL 0)
+                set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name})
+                set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}/${thirdparty_name})
+                find_package(${package} REQUIRED)
             else()
                 message(FATAL_ERROR "Cannot configure Git submodule ${package}")
             endif()
-            set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name})
-            set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${PROJECT_SOURCE_DIR}/thirdparty/${thirdparty_name}/${thirdparty_name})
         endif()
-
-        find_package(${package} REQUIRED QUIET)
 
     endif()
 endmacro()

--- a/cmake/modules/FindAsio.cmake
+++ b/cmake/modules/FindAsio.cmake
@@ -13,7 +13,7 @@ else()
 
 
     include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(asio DEFAULT_MSG ASIO_INCLUDE_DIR)
+    find_package_handle_standard_args(Asio DEFAULT_MSG ASIO_INCLUDE_DIR)
 
     mark_as_advanced(ASIO_INCLUDE_DIR)
 endif()


### PR DESCRIPTION
This pull solves the issue #3. The bug was related with the Asio library, no system search was done before to add a local distribution, which produces overlapping of header files.
It was solved changing the behavior of CMake find Asio package.